### PR TITLE
Prevent double deletion of json object

### DIFF
--- a/MessagePlayer.h
+++ b/MessagePlayer.h
@@ -367,6 +367,8 @@ public:
   }
 
   bool readJsonStream(aJsonStream &stream) {
+    bool result = false;
+
     // Serial.print(F("Parsing json..."));
     aJsonObject* root = aJson.parse(&stream);
     if (!root) {
@@ -376,7 +378,9 @@ public:
 
     // Serial.println(F(" done"));
 
-    return readJsonObject(root);
+    result = readJsonObject(root);
+    aJson.deleteItem(root);
+    return result;
   }
 
   bool readJsonObject(aJsonObject * root){
@@ -445,8 +449,6 @@ public:
       // Serial.print(F("scrollMode: "));
       // Serial.println(scrollMode);
     }
-
-    aJson.deleteItem(root);
 
     return true;
   }


### PR DESCRIPTION
readSerialCommand was deleting the json object after calling readJsonObject and readJsonObject was deleting the object causing a program crash.

I changed the invocation of in readJsonStream to also handle deleting the object outside of readJsonObject like readSerialCommand does.